### PR TITLE
Support custom image with race detector. Race condition fix.

### DIFF
--- a/BASETEN.md
+++ b/BASETEN.md
@@ -1,0 +1,13 @@
+# Baseten gpu-operator fork
+This fork is for a temporary workaround of a race-condition that is causing crashes (fatal error: concurrent map read and map write).
+
+## Custom build image
+Use the Dockerfile in the root directory. We used the official compatible version base image (e.g. nvcr.io/nvidia/gpu-operator:v23.9.1) and then override the gpu-operator binary. By doing this we remove the need to do all the dependency packaging that is requried to build a working image (see /docker folder for their docker file).
+
+Modify the Dockerfile with the make target depending on whether you want the normal binary or the binary with race detector.
+
+
+## Compile binary with golang race detector
+Use the `gpu-operator-race` target.
+
+Race detector requires CGO. To get around the glibc dynamic linking issues (image needs compatiable lib installed) we use static linking which forces the binary to include the dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21 AS builder
+
+WORKDIR /
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make gpu-operator-race
+
+FROM nvcr.io/nvidia/gpu-operator:v23.9.1
+WORKDIR /
+COPY --from=builder /gpu-operator /usr/bin/
+
+USER gpu-operator
+ENTRYPOINT ["/usr/bin/gpu-operator"]

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ gpu-operator:
 	CGO_ENABLED=0 GOOS=$(GOOS) \
 		go build -ldflags "-s -w -X $(VERSION_PKG).gitCommit=$(GIT_COMMIT) -X $(VERSION_PKG).version=$(VERSION)" -o gpu-operator main.go
 
+gpu-operator-race:
+	CGO_ENABLED=1 GOOS=$(GOOS) CGO_LDFLAGS="-static" \
+		go build -ldflags "-s -w -X $(VERSION_PKG).gitCommit=$(GIT_COMMIT) -X $(VERSION_PKG).version=$(VERSION)" -o gpu-operator ./cmd/gpu-operator/...
+
+
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate check manifests
 	go run ./main.go

--- a/controllers/state_manager.go
+++ b/controllers/state_manager.go
@@ -23,15 +23,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	secv1 "github.com/openshift/api/security/v1"
-	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/v1"
 
 	"github.com/go-logr/logr"
 	apiconfigv1 "github.com/openshift/api/config/v1"
-	apiimagev1 "github.com/openshift/api/image/v1"
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
@@ -782,11 +777,6 @@ func (n *ClusterPolicyController) init(ctx context.Context, reconciler *ClusterP
 		}
 		n.k8sVersion = k8sVersion
 		n.rec.Log.Info("Kubernetes version detected", "version", k8sVersion)
-
-		utilruntime.Must(promv1.AddToScheme(reconciler.Scheme))
-		utilruntime.Must(secv1.Install(reconciler.Scheme))
-		utilruntime.Must(apiconfigv1.Install(reconciler.Scheme))
-		utilruntime.Must(apiimagev1.Install(reconciler.Scheme))
 
 		n.operatorMetrics = initOperatorMetrics(n)
 		n.rec.Log.Info("Operator metrics initialized.")


### PR DESCRIPTION
Fix race condition with AddToSchema in ClusterPolicyController.init()

See issue: https://github.com/NVIDIA/gpu-operator/issues/689#issuecomment-2035095370

The write side stack trace from race detector:
`WARNING: DATA RACE
Write at 0x00c0000eb3b0 by goroutine 194:
  runtime.mapassign()
      /usr/local/go/src/runtime/map.go:579 +0x0
  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName()
      /vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:174 +0x357
  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypes()
      /vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:148 +0x205
  github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.addKnownTypes()
      /vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/register.go:49 +0x7fe
  k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme()
      /vendor/k8s.io/apimachinery/pkg/runtime/scheme_builder.go:29 +0xa1
  k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme-fm()
      <autogenerated>:1 +0x1f
  github.com/NVIDIA/gpu-operator/controllers.(*ClusterPolicyController).init()
      /controllers/state_manager.go:786 +0x663
  github.com/NVIDIA/gpu-operator/controllers.(*ClusterPolicyReconciler).Reconcile()
      /controllers/clusterpolicy_controller.go:128 +0x6cb `
      
      
     